### PR TITLE
prevent crashing when there is no match

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -24,7 +24,7 @@ function getranges()
 end
 
 function skip_ads(name,pos)
-	if pos ~= nil then
+	if pos ~= nil and ranges ~= nil then
 		for k,v in pairs(ranges) do
 			if tonumber(k) <= pos and tonumber(v) > pos then
 				--this message may sometimes be wrong


### PR DESCRIPTION
I have this enabled by default by putting toggle at the end of the file... so there are always crashes. checking if range is nil prevents those crashes

```
mp.register_event("file-loaded", file_loaded)

toggle()
```
